### PR TITLE
Allow lib path for HCR

### DIFF
--- a/nimja.nimble
+++ b/nimja.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.6.1"
+version       = "0.6.2"
 author        = "David Krause"
 description   = "typed and compiled template engine inspired by jinja2, twig and onionhammer/nim-templates for Nim."
 license       = "MIT"

--- a/src/nimja/hcrutils.nim
+++ b/src/nimja/hcrutils.nim
@@ -42,7 +42,8 @@ proc newChangeWatcher*(patterns: seq[string], exec: Exec = doRecompile, checkTim
   result = ChangeWatcher()
   result.exec = exec
   result.checkTimeout = checkTimeout
-  result.libfile = splitFile(libfile).name
+  let lbp = splitFile(libfile)
+  result.libfile = lbp.dir / lbp.name
   result.patterns = patterns
   result.patterns.add libfile # always add the libfile
   result.doRecompile() # compile the lib once on start


### PR DESCRIPTION
The `libfile` parameter for `newChangeWatcher` doesn't accept paths (like `src/views.nim`, which is troublesome for projects where the render file isn't located at root.

This pull makes a simple change to the function to keep the libfile path.