### PR TITLE
Massive truncate() performance gain.

### DIFF
--- a/nimja.nimble
+++ b/nimja.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.6.2"
+version       = "0.6.3"
 author        = "David Krause"
 description   = "typed and compiled template engine inspired by jinja2, twig and onionhammer/nim-templates for Nim."
 license       = "MIT"

--- a/src/nimja/nimjautils.nim
+++ b/src/nimja/nimjautils.nim
@@ -4,7 +4,7 @@ import sharedhelper
 import strutils
 import parseutils
 import unidecode
-import os, mimetypes, uri, tables, macros
+import os, mimetypes, uri, tables, macros, std/enumerate
 export uri
 
 type
@@ -119,7 +119,8 @@ proc truncate*(str: string, num: Natural, preserveWords = true, suf = "..."): st
   if preserveWords == false:
     return str[0 .. num - 1] & suf
   else:
-    for idx, word in str.splitWhitespace.pairs():
+    result = newStringOfCap(num + suf.len)
+    for idx, word in enumerate(str.splitWhitespace()):
       if result.len + (word.len) <= num:
         if idx != 0:
           result.add " "


### PR DESCRIPTION
```
name ............................... min time      avg time    std dv   runs
truncate .......................... 11.765 ms     13.770 ms    ±1.686   x360
truncate2 .......................... 0.025 ms      0.041 ms    ±0.024  x1000
truncate3 .......................... 0.025 ms      0.033 ms    ±0.009  x1000
```

Signed-off-by: David Krause <enthus1ast@users.noreply.github.com>