### PR TITLE
Associate .nwt file in VSCode for color syntax

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -966,15 +966,16 @@ asyncCheck cw.recompile() # if a change is detected we recompile tmpls.nim
 line.
 
 
-Nimja .nwt VSCode Syntax Color Formatting
+Nimja Template VSCode Syntax Color Formatting
 ============================================
 If you are using VSCode to develop your nim app,
-you can still associate .nwt files for color syntax and formating with vscode as an html file.
+you can still associate nimja template files for color syntax and formating with vscode as an html file.
 Add this segment to your settings.json in vscode:
 
 ```json
   "files.associations": {
-    "*.nwt": "html",
+    "*.nwt": "html", // Nimja deprecated templates
+    "*.nimja": "html", // Nimja deprecated templates
   },
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -975,7 +975,7 @@ Add this segment to your settings.json in vscode:
 ```json
   "files.associations": {
     "*.nwt": "html", // Nimja deprecated templates
-    "*.nimja": "html", // Nimja deprecated templates
+    "*.nimja": "html", // Nimja new templates
   },
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -966,7 +966,17 @@ asyncCheck cw.recompile() # if a change is detected we recompile tmpls.nim
 line.
 
 
+Nimja .nwt VSCode Syntax Color Formatting
+============================================
+If you are using VSCode to develop your nim app,
+you can still associate .nwt files for color syntax and formating with vscode as an html file.
+Add this segment to your settings.json in vscode:
 
+```json
+  "files.associations": {
+    "*.nwt": "html",
+  },
+```
 
 Debugging
 =====================


### PR DESCRIPTION
Add new section to explain how to associate .nwt file in vscode for color syntax and formatting.