### PR TITLE
make case-stmt work without whitespace-control

### DIFF
--- a/src/nimja/parser.nim
+++ b/src/nimja/parser.nim
@@ -181,6 +181,9 @@ proc parseSsCase(fsTokens: seq[FsNode], pos: var int): NwtNode =
       pos.inc
       result = NwtNode(kind: NwtNodeKind.NCase)
       result.caseStmt = elem.value
+      let nextElem = fsTokens[pos]
+      if nextElem.kind == FsStr and nextElem.value.isEmptyOrWhitespace:
+        pos.inc
     of FsOf:
       pos.inc
       result.nnCaseOf.add NwtNode(kind: NCaseOf, caseOfStmt: elem.value)


### PR DESCRIPTION
lets this compile by ignoring space after `case`
```nim
{% case x %}
{% of 0 %}zero
{% else %}positive
{% endcase %}
```

its not realy that neccesary and maybe strictly spoken wrong semantics because it ignores spaces implicitly. But it was something that irretatet me while, so I thought it might others too.